### PR TITLE
0.4.1: align reference-doc surface with canonical public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-29
+
+Documentation discoverability fixes — no API changes for end users. The reference docs at `reference.langchain.com/python/langchain-parallel` were rendering pages under the legacy class names (`ChatParallelWeb`, `ParallelWebSearchTool`) and at private module paths (`_types`, `_client`); this release reorganizes the source so the auto-generated reference matches the canonical names used in user-facing docs.
+
+### Changed
+
+- **Canonical class definitions flipped.** `ChatParallel` is now the actual class definition; `ChatParallelWeb` is a back-compat alias (`ChatParallelWeb = ChatParallel`). Same flip for `ParallelSearchTool` / `ParallelWebSearchTool`. Both old and new names continue to import and `isinstance(x, ChatParallelWeb)` continues to work — they're the same class object.
+- **`langchain_parallel._types` → `langchain_parallel.types`.** The settings classes (`ExcerptSettings`, `FetchPolicy`, `FullContentSettings`, `SourcePolicy`) now live at the public `types` module path; `_types` remains as a re-export shim so any code importing from the old path keeps working.
+- **`langchain_parallel._client`** declares `__all__: list[str] = []` and a "private module" docstring so reference-doc tooling treats it as internal. No public API change — these helpers were never exported from the package root.
+
+### Migration
+
+No code changes required. The two flipped classes and the renamed settings module are fully backward compatible:
+
+- `from langchain_parallel import ChatParallelWeb` and `from langchain_parallel import ChatParallel` both work and resolve to the same class.
+- `from langchain_parallel import ParallelWebSearchTool` and `from langchain_parallel import ParallelSearchTool` both work and resolve to the same class.
+- `from langchain_parallel._types import ExcerptSettings` continues to work via the back-compat shim; new code should prefer `from langchain_parallel.types import ExcerptSettings` (or the package root: `from langchain_parallel import ExcerptSettings`).
+
 ## [0.4.0] - 2026-04-28
 
 This is a feature release covering Phase 2 of the modernization roadmap. Adds five new public surfaces (retriever, Task API, FindAll, Monitor, MCP toolkit) and removes the deprecation paths that 0.3.0 introduced.

--- a/langchain_parallel/__init__.py
+++ b/langchain_parallel/__init__.py
@@ -1,11 +1,5 @@
 from importlib import metadata
 
-from langchain_parallel._types import (
-    ExcerptSettings,
-    FetchPolicy,
-    FullContentSettings,
-    SourcePolicy,
-)
 from langchain_parallel.chat_models import ChatParallel, ChatParallelWeb
 from langchain_parallel.extract_tool import ParallelExtractTool
 from langchain_parallel.findall import (
@@ -25,6 +19,12 @@ from langchain_parallel.tasks import (
     build_task_spec,
     parse_basis,
     verify_webhook,
+)
+from langchain_parallel.types import (
+    ExcerptSettings,
+    FetchPolicy,
+    FullContentSettings,
+    SourcePolicy,
 )
 
 try:

--- a/langchain_parallel/_client.py
+++ b/langchain_parallel/_client.py
@@ -1,4 +1,8 @@
-"""Client utilities for Parallel integration."""
+"""Internal client utilities for Parallel integration.
+
+Private module. Helpers in here are not part of the public API and may
+change without notice; import from :mod:`langchain_parallel` instead.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +11,8 @@ from typing import Optional
 
 import openai
 from parallel import AsyncParallel, Parallel
+
+__all__: list[str] = []
 
 
 def get_api_key(api_key: Optional[str] = None) -> str:

--- a/langchain_parallel/_types.py
+++ b/langchain_parallel/_types.py
@@ -1,115 +1,22 @@
-"""Common types for Parallel API."""
+"""Back-compat shim for the renamed :mod:`langchain_parallel.types` module.
 
-from __future__ import annotations
+The settings classes (``ExcerptSettings``, ``FetchPolicy``, ``FullContentSettings``,
+``SourcePolicy``) live in :mod:`langchain_parallel.types` as of 0.4.1. This shim
+re-exports them so any code that imported from ``langchain_parallel._types``
+keeps working; new code should import from ``langchain_parallel.types`` (or
+the package root) directly.
+"""
 
-import datetime as _dt
-from typing import Optional, Union
+from langchain_parallel.types import (
+    ExcerptSettings,
+    FetchPolicy,
+    FullContentSettings,
+    SourcePolicy,
+)
 
-from pydantic import BaseModel, Field, field_validator, model_validator
-
-
-class ExcerptSettings(BaseModel):
-    """Settings for excerpt extraction."""
-
-    max_chars_per_result: Optional[int] = Field(
-        default=None,
-        description=(
-            "Optional upper bound on the total number of characters to include "
-            "per url. Excerpts may contain fewer characters than this limit to "
-            "maximize relevance and token efficiency."
-        ),
-    )
-
-
-class FullContentSettings(BaseModel):
-    """Settings for full content extraction."""
-
-    max_chars_per_result: Optional[int] = Field(
-        default=None,
-        description=(
-            "Optional limit on the number of characters to include in the full "
-            "content for each url. Full content always starts at the beginning "
-            "of the page and is truncated at the limit if necessary."
-        ),
-    )
-
-
-class FetchPolicy(BaseModel):
-    """Fetch policy for cache vs live content."""
-
-    max_age_seconds: Optional[int] = Field(
-        default=None,
-        ge=600,
-        description=(
-            "If cached content is older than this, fetch fresh content from the "
-            "source. Minimum 600 seconds (10 minutes); if not provided, the API "
-            "uses a dynamic age policy."
-        ),
-    )
-    timeout_seconds: Optional[float] = Field(
-        default=None,
-        description=(
-            "Timeout in seconds for fetching live content if unavailable in cache. "
-            "If unspecified, dynamic timeout will be used (15-60 seconds)."
-        ),
-    )
-    disable_cache_fallback: bool = Field(
-        default=False,
-        description=(
-            "If false, fallback to cached content older than max-age if live "
-            "fetch fails or times out. If true, returns an error instead."
-        ),
-    )
-
-
-class SourcePolicy(BaseModel):
-    """Domain allow/deny lists and freshness floor for web research.
-
-    Apex-domain semantics: include `nature.com`, not `https://www.nature.com`.
-    Wildcards permitted (e.g. `.org`).
-    """
-
-    include_domains: Optional[list[str]] = Field(
-        default=None,
-        max_length=200,
-        description=(
-            "If provided, only sources from these apex domains are returned. "
-            "Combined include + exclude lists are capped at 200 domains."
-        ),
-    )
-    exclude_domains: Optional[list[str]] = Field(
-        default=None,
-        max_length=200,
-        description="If provided, sources from these apex domains are excluded.",
-    )
-    after_date: Optional[Union[_dt.date, str]] = Field(
-        default=None,
-        description=(
-            "ISO date (YYYY-MM-DD). Only return sources published on or after "
-            "this date."
-        ),
-    )
-
-    @field_validator("after_date", mode="before")
-    @classmethod
-    def _parse_after_date(cls, v: object) -> object:
-        if v is None or isinstance(v, _dt.date):
-            return v
-        if isinstance(v, str):
-            try:
-                return _dt.date.fromisoformat(v)
-            except ValueError as e:
-                msg = f"after_date must be ISO YYYY-MM-DD; got {v!r} ({e!s})."
-                raise ValueError(msg) from e
-        return v
-
-    @model_validator(mode="after")
-    def _check_domain_total(self) -> SourcePolicy:
-        total = len(self.include_domains or []) + len(self.exclude_domains or [])
-        if total > 200:
-            msg = (
-                f"Combined include_domains + exclude_domains has {total} entries; "
-                f"the API caps the total at 200."
-            )
-            raise ValueError(msg)
-        return self
+__all__ = [
+    "ExcerptSettings",
+    "FetchPolicy",
+    "FullContentSettings",
+    "SourcePolicy",
+]

--- a/langchain_parallel/chat_models.py
+++ b/langchain_parallel/chat_models.py
@@ -1,6 +1,6 @@
-"""Parallel Web chat model integration.
+"""ChatParallel chat model integration.
 
-This module provides the ChatParallelWeb class for interacting with Parallel's
+This module provides the ChatParallel class for interacting with Parallel's
 Chat API through an OpenAI-compatible interface.
 """
 
@@ -165,8 +165,8 @@ def _merge_consecutive_messages(messages: list[BaseMessage]) -> list[BaseMessage
     return merged
 
 
-class ChatParallelWeb(BaseChatModel):
-    """Parallel Web chat model integration.
+class ChatParallel(BaseChatModel):
+    """ChatParallel chat model integration.
 
     This integration connects to Parallel's Chat API, which provides
     real-time web research capabilities through an OpenAI-compatible interface.
@@ -201,9 +201,9 @@ class ChatParallelWeb(BaseChatModel):
 
     Instantiate:
         ```python
-        from langchain_parallel import ChatParallelWeb
+        from langchain_parallel import ChatParallel
 
-        llm = ChatParallelWeb(
+        llm = ChatParallel(
             model="speed",
             temperature=0.7,
             max_tokens=None,
@@ -664,7 +664,7 @@ class ChatParallelWeb(BaseChatModel):
                 f"Structured output requires one of the research models "
                 f"({sorted(_STRUCTURED_OUTPUT_MODELS)}); the '{self.model}' "
                 f"model silently ignores response_format. Re-instantiate with "
-                f"`ChatParallelWeb(model='lite' | 'base' | 'core')`."
+                f"`ChatParallel(model='lite' | 'base' | 'core')`."
             )
             raise ValueError(msg)
         if method == "function_calling":
@@ -734,8 +734,8 @@ class ChatParallelWeb(BaseChatModel):
         return bound | output_parser
 
 
-#: Forward-compat alias for :class:`ChatParallelWeb`.
+#: Back-compat alias for :class:`ChatParallel`.
 #:
-#: Prefer ChatParallel in new code; ChatParallelWeb will continue to
-#: work indefinitely as an alias for this class.
-ChatParallel = ChatParallelWeb
+#: ``ChatParallelWeb`` is the legacy class name and continues to work
+#: indefinitely; new code should prefer ``ChatParallel``.
+ChatParallelWeb = ChatParallel

--- a/langchain_parallel/extract_tool.py
+++ b/langchain_parallel/extract_tool.py
@@ -13,7 +13,7 @@ from parallel import AsyncParallel, Parallel
 from pydantic import BaseModel, Field, SecretStr, model_validator
 
 from ._client import get_api_key, get_async_parallel_client, get_parallel_client
-from ._types import ExcerptSettings, FetchPolicy, FullContentSettings
+from .types import ExcerptSettings, FetchPolicy, FullContentSettings
 
 
 def _coerce_full_content(

--- a/langchain_parallel/retrievers.py
+++ b/langchain_parallel/retrievers.py
@@ -14,7 +14,7 @@ from parallel import AsyncParallel, Parallel
 from pydantic import Field, SecretStr, model_validator
 
 from ._client import get_api_key, get_async_parallel_client, get_parallel_client
-from ._types import ExcerptSettings, FetchPolicy, SourcePolicy
+from .types import ExcerptSettings, FetchPolicy, SourcePolicy
 
 
 def _join_excerpts(excerpts: Optional[list[str]]) -> str:

--- a/langchain_parallel/search_tool.py
+++ b/langchain_parallel/search_tool.py
@@ -14,7 +14,7 @@ from parallel import AsyncParallel, Parallel
 from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 from ._client import get_api_key, get_async_parallel_client, get_parallel_client
-from ._types import ExcerptSettings, FetchPolicy, SourcePolicy
+from .types import ExcerptSettings, FetchPolicy, SourcePolicy
 
 _VALID_MODES = {"basic", "advanced"}
 
@@ -180,7 +180,7 @@ class ParallelWebSearchInput(BaseModel):
     )
 
 
-class ParallelWebSearchTool(BaseTool):
+class ParallelSearchTool(BaseTool):
     """Parallel Search tool with web research capabilities.
 
     This tool calls Parallel's Search API, which streamlines the traditional
@@ -206,9 +206,9 @@ class ParallelWebSearchTool(BaseTool):
 
     Instantiation:
         ```python
-        from langchain_parallel import ParallelWebSearchTool
+        from langchain_parallel import ParallelSearchTool
 
-        tool = ParallelWebSearchTool()
+        tool = ParallelSearchTool()
         ```
 
     Invocation:
@@ -292,7 +292,7 @@ class ParallelWebSearchTool(BaseTool):
     """Asynchronous Parallel SDK client (initialized after validation)."""
 
     @model_validator(mode="after")
-    def validate_environment(self) -> ParallelWebSearchTool:
+    def validate_environment(self) -> ParallelSearchTool:
         """Validate the environment and initialize SDK clients."""
         api_key_str = get_api_key(
             self.api_key.get_secret_value() if self.api_key else None,
@@ -534,8 +534,8 @@ class ParallelWebSearchTool(BaseTool):
         return response
 
 
-#: Forward-compat alias for :class:`ParallelWebSearchTool`.
+#: Back-compat alias for :class:`ParallelSearchTool`.
 #:
-#: Prefer ParallelSearchTool in new code; ParallelWebSearchTool will
-#: continue to work indefinitely as an alias for this class.
-ParallelSearchTool = ParallelWebSearchTool
+#: ``ParallelWebSearchTool`` is the legacy class name and continues to
+#: work indefinitely; new code should prefer ``ParallelSearchTool``.
+ParallelWebSearchTool = ParallelSearchTool

--- a/langchain_parallel/types.py
+++ b/langchain_parallel/types.py
@@ -1,0 +1,115 @@
+"""Common types for Parallel API."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class ExcerptSettings(BaseModel):
+    """Settings for excerpt extraction."""
+
+    max_chars_per_result: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional upper bound on the total number of characters to include "
+            "per url. Excerpts may contain fewer characters than this limit to "
+            "maximize relevance and token efficiency."
+        ),
+    )
+
+
+class FullContentSettings(BaseModel):
+    """Settings for full content extraction."""
+
+    max_chars_per_result: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional limit on the number of characters to include in the full "
+            "content for each url. Full content always starts at the beginning "
+            "of the page and is truncated at the limit if necessary."
+        ),
+    )
+
+
+class FetchPolicy(BaseModel):
+    """Fetch policy for cache vs live content."""
+
+    max_age_seconds: Optional[int] = Field(
+        default=None,
+        ge=600,
+        description=(
+            "If cached content is older than this, fetch fresh content from the "
+            "source. Minimum 600 seconds (10 minutes); if not provided, the API "
+            "uses a dynamic age policy."
+        ),
+    )
+    timeout_seconds: Optional[float] = Field(
+        default=None,
+        description=(
+            "Timeout in seconds for fetching live content if unavailable in cache. "
+            "If unspecified, dynamic timeout will be used (15-60 seconds)."
+        ),
+    )
+    disable_cache_fallback: bool = Field(
+        default=False,
+        description=(
+            "If false, fallback to cached content older than max-age if live "
+            "fetch fails or times out. If true, returns an error instead."
+        ),
+    )
+
+
+class SourcePolicy(BaseModel):
+    """Domain allow/deny lists and freshness floor for web research.
+
+    Apex-domain semantics: include `nature.com`, not `https://www.nature.com`.
+    Wildcards permitted (e.g. `.org`).
+    """
+
+    include_domains: Optional[list[str]] = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "If provided, only sources from these apex domains are returned. "
+            "Combined include + exclude lists are capped at 200 domains."
+        ),
+    )
+    exclude_domains: Optional[list[str]] = Field(
+        default=None,
+        max_length=200,
+        description="If provided, sources from these apex domains are excluded.",
+    )
+    after_date: Optional[Union[_dt.date, str]] = Field(
+        default=None,
+        description=(
+            "ISO date (YYYY-MM-DD). Only return sources published on or after "
+            "this date."
+        ),
+    )
+
+    @field_validator("after_date", mode="before")
+    @classmethod
+    def _parse_after_date(cls, v: object) -> object:
+        if v is None or isinstance(v, _dt.date):
+            return v
+        if isinstance(v, str):
+            try:
+                return _dt.date.fromisoformat(v)
+            except ValueError as e:
+                msg = f"after_date must be ISO YYYY-MM-DD; got {v!r} ({e!s})."
+                raise ValueError(msg) from e
+        return v
+
+    @model_validator(mode="after")
+    def _check_domain_total(self) -> SourcePolicy:
+        total = len(self.include_domains or []) + len(self.exclude_domains or [])
+        if total > 200:
+            msg = (
+                f"Combined include_domains + exclude_domains has {total} entries; "
+                f"the API caps the total at 200."
+            )
+            raise ValueError(msg)
+        return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-parallel"
-version = "0.4.0"
+version = "0.4.1"
 description = "A LangChain integration for Parallel Web AI services, including Chat and Search."
 authors = ["Parallel Team <support@parallel.ai>"]
 readme = "README.md"

--- a/tests/unit_tests/test_extract_tool.py
+++ b/tests/unit_tests/test_extract_tool.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from langchain_parallel._types import ExcerptSettings, FetchPolicy, FullContentSettings
 from langchain_parallel.extract_tool import ParallelExtractTool
+from langchain_parallel.types import ExcerptSettings, FetchPolicy, FullContentSettings
 
 
 def _make_response(payload: dict) -> SimpleNamespace:

--- a/tests/unit_tests/test_search_tool.py
+++ b/tests/unit_tests/test_search_tool.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from langchain_parallel._types import ExcerptSettings, FetchPolicy, SourcePolicy
 from langchain_parallel.search_tool import ParallelWebSearchTool, _validate_mode
+from langchain_parallel.types import ExcerptSettings, FetchPolicy, SourcePolicy
 
 
 def _make_response(payload: dict) -> SimpleNamespace:


### PR DESCRIPTION
## Why

The reference docs at [`reference.langchain.com/python/langchain-parallel`](https://reference.langchain.com/python/langchain-parallel) (auto-generated by langchain-ai) were rendering pages under the legacy class names and at private module paths:

- Per-class pages titled `ChatParallelWeb` / `ParallelWebSearchTool`, even though the user-facing integration docs at [`docs.langchain.com/oss/integrations/chat/parallel`](https://docs.langchain.com/oss/integrations/chat/parallel) (and friends) promote `ChatParallel` / `ParallelSearchTool` as the canonical names.
- Settings classes (`ExcerptSettings`, `FetchPolicy`, `FullContentSettings`, `SourcePolicy`) rendering at private paths like `langchain-parallel/_types/SourcePolicy`.
- Internal `_client.py` helpers showing up in the package's "Functions" list.

This is purely a doc-discoverability problem — no end-user code change is required. The fix is to flip the source-side relationship so the canonical names are the actual class definitions and the legacy names are the aliases, plus rename the `_types` module to drop the leading underscore.

## What changed

**Class-definition flip (back-compat preserved)**

- `ChatParallel` is now the actual `class` definition; `ChatParallelWeb = ChatParallel` is the back-compat alias.
- `ParallelSearchTool` is now the actual `class` definition; `ParallelWebSearchTool = ParallelSearchTool` is the back-compat alias.
- Both old and new names continue to import. `isinstance(x, ChatParallelWeb)` continues to work — they're the same class object.

```python
>>> from langchain_parallel import ChatParallel, ChatParallelWeb
>>> ChatParallel is ChatParallelWeb
True
>>> ChatParallel.__name__
'ChatParallel'      # was 'ChatParallelWeb' before — this is what reference docs will pick up
```

**`_types` → `types` rename**

- `langchain_parallel/_types.py` → `langchain_parallel/types.py` (the public settings classes now live at the public module path).
- A 1-file `_types.py` shim re-exports everything from `types`, so any code that imported from `langchain_parallel._types` keeps working.

**`_client.py` marked private**

- Adds `__all__: list[str] = []` and an explicit "private module" docstring so reference-doc tooling treats it as internal. The functions inside (`get_api_key`, `get_parallel_client`, etc.) were never exported from the package root and remain implementation detail.

## Migration

**No code changes required.** All four call sites continue to work:

- `from langchain_parallel import ChatParallelWeb` ✅
- `from langchain_parallel import ChatParallel` ✅
- `from langchain_parallel import ParallelWebSearchTool` ✅
- `from langchain_parallel import ParallelSearchTool` ✅
- `from langchain_parallel._types import ExcerptSettings` ✅ (via shim)
- `from langchain_parallel.types import ExcerptSettings` ✅ (preferred)
- `from langchain_parallel import ExcerptSettings` ✅ (preferred)

## Verification

- All 87 unit tests pass; 2 xfail unchanged.
- `ruff check` clean; `ruff format --check` clean; `mypy` clean.
- Public API surface verified by import + identity check (`ChatParallel is ChatParallelWeb` etc.).

## What this *doesn't* fix

The "Modules" section on the reference page is scraped from `providers/parallel.mdx` in the langchain-ai/docs repo, not from the package source. That section will refresh on its own once reference.langchain.com rebuilds against [langchain-ai/docs#3787](https://github.com/langchain-ai/docs/pull/3787) (already merged). No package-side change needed for that one.

## AI agent disclosure

Authored with substantial assistance from Claude. All changes were verified against the package source, executed via the unit test suite, and confirmed to preserve the public API via direct import checks.